### PR TITLE
Added Loading Animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,22 @@ class MyApp extends StatelessWidget {
 With this code, you'll see a shimmering loading indicator in the center of the screen.
 
 Shimmer animations can greatly enhance the user experience in your Flutter app by providing engaging visual feedback during loading or emphasizing certain UI elements. You can use them creatively to make your app more attractive and user-friendly.
+
+
+# Flutter Loading Animation
+
+Welcome to the Flutter Loading Animation project, a demonstration of a loading animation with a radial progress indicator. This README provides an overview of the project, its features, and how to use it.
+
+## Introduction
+
+This Flutter application showcases a loading animation with a radial progress indicator. When you click the "Start" button, the animation begins, and the progress gradually increases to a specified value. The primary goal is to demonstrate how to create an interactive loading animation in Flutter.
+
+## Key Features
+
+- **Loading Animation:** This application features a loading animation with a radial progress indicator.
+
+- **Dynamic Configuration:** You can customize the progress value and color of the loading animation.
+
+- **Interactive Button:** There's an "Start" button that you can click to trigger the animation.
+
+

--- a/lib/Controllers/drawercontroller.dart
+++ b/lib/Controllers/drawercontroller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_animations/Screens/explicit_animation.dart';
 import 'package:flutter_animations/Screens/fade_in_fade_out.dart';
 import 'package:flutter_animations/Screens/flip_counter.dart';
+import 'package:flutter_animations/Screens/loading_animation.dart';
 import 'package:flutter_animations/Screens/water_drop_effect.dart';
 import 'package:flutter_animations/Screens/ripple_animation.dart';
 import 'package:flutter_animations/Text/tex_screen.dart';
@@ -27,6 +28,7 @@ class MyDrawerController extends GetxController {
   final mainScreen7 = ExplicitAnimations();
   final mainScreen8 = AnimatedDialog();
   final mainScreen9 = flip();
+  final mainScreen10=loadingAnimation();
 
   // Getter to get the current main screen based on the selectedMenuItem
   Widget get currentMainScreen {
@@ -48,7 +50,9 @@ class MyDrawerController extends GetxController {
       case 7 :
         return  mainScreen8 ;
       case 8 : 
-        return  mainScreen9 ;  
+        return  mainScreen9;
+        case 9 :
+        return  mainScreen10 ;
 
       default:
         return mainScreen1; // Default to mainScreen1 if the selection is not recognized

--- a/lib/Screens/loading_animation.dart
+++ b/lib/Screens/loading_animation.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animations/helpers/colors.dart';
+import '../controllers/drawercontroller.dart';
+
+class loadingAnimation extends StatefulWidget {
+  const loadingAnimation({super.key});
+
+  @override
+  State<loadingAnimation> createState() => _loadingAnimation();
+}
+
+class _loadingAnimation extends State<loadingAnimation> {
+  bool _visible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: mainpagecolor,
+      appBar: AppBar(
+        backgroundColor: mainpagecolor,
+        title: const Text('Loading Animation'),
+        leading: IconButton(
+          icon: const Icon(Icons.menu),
+          onPressed: () {
+            MyDrawerController.to.toggleDrawer();
+            MyDrawerController.to.update();
+          },
+          hoverColor: Colors.white,
+        ),
+        elevation: 0,
+      ),
+      body: Center(
+        child: RadialProgressAnimation(
+          progress: 0.86,
+          color: Colors.orange,
+        ),
+      ),
+    );
+  }
+}
+
+class RadialProgressAnimation extends StatefulWidget {
+  final double progress;
+  final Color color;
+
+  const RadialProgressAnimation({
+    super.key,
+    required this.progress,
+    required this.color,
+  });
+
+  @override
+  State<RadialProgressAnimation> createState() =>
+      _RadialProgressAnimationState();
+}
+
+class _RadialProgressAnimationState extends State<RadialProgressAnimation>
+    with SingleTickerProviderStateMixin {
+  late AnimationController controller;
+  late Animation<double> animation;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    );
+
+    animation = Tween(begin: 0.0, end: widget.progress).animate(controller);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: AnimatedBuilder(
+          animation: animation,
+          builder: (context, child) {
+            return Stack(
+              alignment: Alignment.center,
+              children: [
+                SizedBox(
+                  width: 150,
+                  height: 150,
+                  child: CircularProgressIndicator(
+                    value: animation.value,
+                    strokeWidth: 10,
+                    backgroundColor: Colors.grey.shade100,
+                    color: widget.color,
+                  ),
+                ),
+                Text(
+                  '${(animation.value * 100).toInt()}%',
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          controller.forward();
+        },
+        child: const Icon(Icons.start),
+      ),
+    );
+  }
+}

--- a/lib/Screens/loading_animation.dart
+++ b/lib/Screens/loading_animation.dart
@@ -10,7 +10,7 @@ class loadingAnimation extends StatefulWidget {
 }
 
 class _loadingAnimation extends State<loadingAnimation> {
-  bool _visible = true;
+  bool visible = true;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/Screens/menuscreen.dart
+++ b/lib/Screens/menuscreen.dart
@@ -20,8 +20,10 @@ class MenuScreen extends GetView<MyDrawerController> {
     'Ripple Effect',
     'Bounce Animation',
     "Explicit Animation",
-    "Animated Dialog"
-    "FlipCounter Animation "
+    "Animated Dialog",
+    "FlipCounter Animation",
+    "Loading Animation",
+
   ];
 
   @override


### PR DESCRIPTION
#Hacktober Fest 2023
1. Added New Animation: Loading Animation-> it displays a circular loading animation with a button to start functioning (currently set to 86%).

https://github.com/dev1abhi/Flutter-Animations/assets/128305006/507da9da-a6b9-4315-82cb-8eac7fddc99c

2. FIXED: While working, I found an issue in the menu section, the last 2 options had no spaces between leading to bad user experience and functionality as they both navigated to the same page. I fixed it by separating them, and it's all fine now.
THEN->
<img width="297" alt="Screenshot 2023-10-19 at 9 01 17 PM" src="https://github.com/dev1abhi/Flutter-Animations/assets/128305006/be2a480d-5eaa-4dd3-9c7e-7e7927a9d347">
Now->
<img width="297" alt="Screenshot 2023-10-19 at 10 00 20 PM" src="https://github.com/dev1abhi/Flutter-Animations/assets/128305006/fab88999-4784-4164-8e57-88b8ea55fbf0">
